### PR TITLE
Fix: TD-4781 [Linux]Crash while using EBook Custom Stylesheet

### DIFF
--- a/src/CssDialog/ConfigurationTool.cs
+++ b/src/CssDialog/ConfigurationTool.cs
@@ -1063,6 +1063,8 @@ namespace SIL.PublishingSolution
 		private void tabControl1_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			_cToolBL.tabControl1_SelectedIndexChangedBL();
+			_cToolBL.WriteCss();
+			_cToolBL.SaveControlPropertyValues();
 		}
 
 		private void tsSaveAs_Click(object sender, EventArgs e)

--- a/src/CssDialog/ConfigurationToolBL.cs
+++ b/src/CssDialog/ConfigurationToolBL.cs
@@ -1040,6 +1040,32 @@ namespace SIL.PublishingSolution
 			_screenMode = ScreenMode.Edit;
 		}
 
+		public void SaveControlPropertyValues()
+		{
+			if (MediaType.ToLower() == "others")
+			{
+				Param.UpdateOthersAtrrib("BaseFontSize", cTool.TxtBaseFontSize.Text, StyleName);
+				Param.UpdateOthersAtrrib("DefaultLineHeight", cTool.TxtDefaultLineHeight.Text, StyleName);
+				Param.UpdateOthersAtrrib("DefaultAlignment",
+					((ComboBoxItem) cTool.DdlDefaultAlignment.SelectedItem).Value, StyleName);
+				Param.UpdateOthersAtrrib("IncludeImage", cTool.ChkIncludeImage.Checked ? "Yes" : "No",
+					StyleName);
+				Param.UpdateOthersAtrrib("MaxImageWidth", cTool.TxtMaxImageWidth.Text, StyleName);
+				Param.UpdateOthersAtrrib("TOCLevel", ((ComboBoxItem) cTool.DdlTocLevel.SelectedItem).Value,
+					StyleName);
+				Param.UpdateOthersAtrrib("PageBreak", cTool.ChkPageBreaks.Checked ? "Yes" : "No", StyleName);
+				Param.UpdateOthersAtrrib("EmbedFonts", cTool.ChkEmbedFonts.Checked ? "Yes" : "No", StyleName);
+				Param.UpdateOthersAtrrib("IncludeFontVariants",
+					cTool.ChkIncludeFontVariants.Checked ? "Yes" : "No", StyleName);
+				Param.UpdateOthersAtrrib("MissingFont",
+					((ComboBoxItem) cTool.DdlMissingFont.SelectedItem).Value, StyleName);
+				Param.UpdateOthersAtrrib("NonSILFont",
+					((ComboBoxItem) cTool.DdlNonSILFont.SelectedItem).Value, StyleName);
+				Param.UpdateOthersAtrrib("DefaultFont",
+					((ComboBoxItem) cTool.DdlDefaultFont.SelectedItem).Value, StyleName);
+			}
+		}
+
 		private void SetAttributesForPaperProperties(StreamWriter writeCss)
 		{
 			var value = new Dictionary<string, string>();
@@ -1233,11 +1259,11 @@ namespace SIL.PublishingSolution
 		{
 			string alignment = string.Empty;
 
-			if (cTool.DdlJustified.SelectedItem != null)
+			if (cTool.DdlDefaultAlignment.SelectedItem != null)
 			{
-				if (cTool.DdlDefaultAlignment.SelectedItem != null)
+				if (((ComboBoxItem) cTool.DdlDefaultAlignment.SelectedItem).Value.Length > 0)
 				{
-					alignment = ((ComboBoxItem)cTool.DdlDefaultAlignment.SelectedItem).Value.ToString(CultureInfo.InvariantCulture);
+					alignment = ((ComboBoxItem) cTool.DdlDefaultAlignment.SelectedItem).Value.ToString(CultureInfo.InvariantCulture);
 				}
 			}
 
@@ -3519,12 +3545,12 @@ namespace SIL.PublishingSolution
 			sb.Append("pt Font, ");
 			sb.Append(cTool.TxtDefaultLineHeight.Text);
 			sb.Append("% Line Height");
-			if (cTool.DdlJustified.SelectedItem != null)
+			if (cTool.DdlDefaultAlignment.SelectedItem != null)
 			{
-				if (cTool.DdlDefaultAlignment.SelectedItem != null)
+				if (((ComboBoxItem) cTool.DdlDefaultAlignment.SelectedItem).Value.Length > 0)
 				{
 					sb.Append(", Alignment: ");
-					sb.Append(((ComboBoxItem)cTool.DdlDefaultAlignment.SelectedItem).Value.ToString(CultureInfo.InvariantCulture));
+					sb.Append(((ComboBoxItem) cTool.DdlDefaultAlignment.SelectedItem).Value.ToString(CultureInfo.InvariantCulture));
 				}
 			}
 

--- a/src/CssDialog/ExportThroughPathway.cs
+++ b/src/CssDialog/ExportThroughPathway.cs
@@ -386,15 +386,15 @@ namespace SIL.PublishingSolution
 	            }
                 LoadAvailFormats();
                 LoadAvailStylesheets();
-                IsExpanded = false;
+	            LoadProperty();
+				IsExpanded = false;
                 ResizeDialog();
                 SetOkStatus();
-                chkHyphen.Enabled = false;
+				chkHyphen.Enabled = false;
                 chkHyphen.Checked = false;
                 clbHyphenlang.Items.Clear();
                 //Loads Hyphenation related settings
 		        LoadHyphenationSettingsToForm();
-	            LoadProperty();
                 EnableUIElements();
 
                 ShowHelp.ShowHelpTopic(this, _helpTopic, _isUnixOS, false);

--- a/src/PsTool/Common.cs
+++ b/src/PsTool/Common.cs
@@ -5153,7 +5153,7 @@ namespace SIL.Tool
 					IDictionary<string, string> value = new Dictionary<string, string>();
 					if (File.Exists(CallerSetting.SettingsFullPath))
 					{
-						var flexScan = new FlexScan(CallerSetting.SettingsFullPath);
+						var flexScan = new FlexScan(CallerSetting.GetSettingsName());
 						foreach (var lang in flexScan.VernWs)
 						{
 							var langname = GetLanguageValues(lang);

--- a/src/PsTool/Common.cs
+++ b/src/PsTool/Common.cs
@@ -3044,8 +3044,10 @@ namespace SIL.Tool
 		public static string GetSaveInFolder(string template, string database, string layout)
 		{
 			Dictionary<string, string> map = new Dictionary<string, string>();
-
-			map["Documents"] = ManageDirectory.ShortFileName(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
+			if(UsingMonoVM)
+				map["Documents"] = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+			else
+				map["Documents"] = ManageDirectory.ShortFileName(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
 
 			map["Base"] = SaveInFolderBase;
             map["CurrentProject"] = MakeValidFileName(database);
@@ -5149,20 +5151,23 @@ namespace SIL.Tool
 				try
 				{
 					IDictionary<string, string> value = new Dictionary<string, string>();
-					var flexScan = new FlexScan(CallerSetting.SettingsFullPath);
-					foreach (var lang in flexScan.VernWs)
+					if (File.Exists(CallerSetting.SettingsFullPath))
 					{
-						var langname = GetLanguageValues(lang);
-						if (!string.IsNullOrEmpty(lang) && (langname != null) && !value.ContainsKey(lang))
-							value.Add(lang, langname.Replace(',', ' '));
+						var flexScan = new FlexScan(CallerSetting.SettingsFullPath);
+						foreach (var lang in flexScan.VernWs)
+						{
+							var langname = GetLanguageValues(lang);
+							if (!string.IsNullOrEmpty(lang) && (langname != null) && !value.ContainsKey(lang))
+								value.Add(lang, langname.Replace(',', ' '));
+						}
+						foreach (var lang in flexScan.AnalWs)
+						{
+							var langname = GetLanguageValues(lang);
+							if (!string.IsNullOrEmpty(lang) && (langname != null) && !value.ContainsKey(lang))
+								value.Add(lang, langname.Replace(',', ' '));
+						}
+						Param.HyphenLang = string.Join(",", value.Select(x => x.Key + ":" + x.Value).ToArray());
 					}
-					foreach (var lang in flexScan.AnalWs)
-					{
-						var langname = GetLanguageValues(lang);
-						if (!string.IsNullOrEmpty(lang) && (langname != null) && !value.ContainsKey(lang))
-							value.Add(lang, langname.Replace(',', ' '));
-					}
-					Param.HyphenLang = string.Join(",", value.Select(x => x.Key + ":" + x.Value).ToArray());
 				}
 				catch (Exception)
 				{


### PR DESCRIPTION
 * Fixed the saving items in other tab property values
 * Fixed the Combobox value not assigned for Alignment
 * Linux doesn't working ManageDirectory short file name
   Modified that based on the environment.
 * Handled in Code to check the hypenation file exist.