### PR TITLE
Fix: TD-4869 Caption Reference appears twice

### DIFF
--- a/src/ParatextSupport/UsfxToXhtml.xsl
+++ b/src/ParatextSupport/UsfxToXhtml.xsl
@@ -560,16 +560,11 @@
 
 		<div class="{$pictureLoc}" xmlns="http://www.w3.org/1999/xhtml">
 			<img id="Figure-{$bookCode}-{$figureNumber}" class="picture" src="{$figurePath}{@file}" alt="{$altFigurePath}{@file}"/>
-			<p lang="{$ws}" class="pictureCaption">
+			<div lang="{$ws}" class="pictureCaption">
 				<span lang="{$ws}">
 					<xsl:value-of select="."/>
 				</span>
-				<span lang="{$ws}" class="reference">
-					<xsl:text> (</xsl:text>
-					<xsl:value-of select="@ref"/>
-					<xsl:text>) </xsl:text>	
-				</span>
-			</p>
+			</div>
 		</div>
 	</xsl:template>
 	


### PR DESCRIPTION
 * Modified the xslt to convert usfx to xhtml
 * Changed the pictureCaption tag P tag to Div tag
   Epub is report an error.