### PR TITLE
Remove the NeedHigher collection

### DIFF
--- a/src/CssSimpler/FlattenStyles.cs
+++ b/src/CssSimpler/FlattenStyles.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------
 #region // Copyright (c) 2016, SIL International. All Rights Reserved.
 // <copyright from='2016' to='2016' company='SIL International'>
 //		Copyright (c) 2016, SIL International. All Rights Reserved.
@@ -34,14 +34,12 @@ namespace CssSimpler
         private readonly ArrayList _savedSibling = new ArrayList(StackSize);
         //private string _lastClass = String.Empty;
         private string _precedingClass = String.Empty;
-        private readonly SortedSet<string> _needHigher;
         private string _headerTag;
 	    private bool _stylesheetPresent;
 
-        public FlattenStyles(string input, string output, XmlDocument xmlCss, SortedSet<string> needHigher, bool noXmlHeader, string decorateStyles)
+        public FlattenStyles(string input, string output, XmlDocument xmlCss, bool noXmlHeader, string decorateStyles)
             : base(input, output, noXmlHeader)
         {
-            _needHigher = needHigher;
 			StyleDecorate = decorateStyles;
             MakeRuleIndex(xmlCss);
             IdentifyDisplayBlockRules(xmlCss);
@@ -732,7 +730,7 @@ namespace CssSimpler
             while (depth > 0)
             {
                 var proposedClass = Classes[depth] as string;
-                if (proposedClass != null && !_needHigher.Contains(proposedClass))
+                if (proposedClass != null)
                     return proposedClass;
                 depth -= 1;
             }

--- a/src/CssSimpler/ProcessPseudo.cs
+++ b/src/CssSimpler/ProcessPseudo.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------
 #region // Copyright (c) 2016, SIL International. All Rights Reserved.
 // <copyright from='2016' to='2016' company='SIL International'>
 //		Copyright (c) 2016, SIL International. All Rights Reserved.
@@ -30,12 +30,10 @@ namespace CssSimpler
         private readonly ArrayList _savedSibling = new ArrayList(StackSize);
         private string _lastClass = String.Empty;
         private string _precedingClass = String.Empty;
-        private readonly SortedSet<string> _needHigher;
 
-        public ProcessPseudo(string input, string output, XmlDocument xmlCss, SortedSet<string> needHigher)
+        public ProcessPseudo(string input, string output, XmlDocument xmlCss)
             : base(input, output, false)
         {
-            _needHigher = needHigher;
             CollectTargets(xmlCss);
             DeclareBefore(XmlNodeType.Attribute, SaveClass);
 			DeclareBefore(XmlNodeType.Element, Program.EntryReporter);
@@ -419,7 +417,7 @@ namespace CssSimpler
             while (depth > 0)
             {
                 var proposedClass = Classes[depth] as string;
-                if (proposedClass != null && !_needHigher.Contains(proposedClass))
+                if (proposedClass != null)
                     return proposedClass;
                 depth -= 1;
             }

--- a/src/CssSimpler/Program.cs
+++ b/src/CssSimpler/Program.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------
 
 #region // Copyright (c) 2016, SIL International. All Rights Reserved.
 
@@ -187,12 +187,12 @@ namespace CssSimpler
 			UniqueClasses = null;
 			LoadCssXml(parser, styleSheet, xml);
 			// ReSharper disable once UnusedVariable
-			var ps = new ProcessPseudo(tmp2Out, extra[0], xml, NeedHigher);
+			var ps = new ProcessPseudo(tmp2Out, extra[0], xml);
 			RemoveCssPseudo(styleSheet, xml);
 			var tmp3Out = Path.GetTempFileName();
 			if (_flatten)
 			{
-				var fs = new FlattenStyles(extra[0], tmp3Out, xml, NeedHigher, _noXmlHeader, _decorateStyles);
+				var fs = new FlattenStyles(extra[0], tmp3Out, xml, _noXmlHeader, _decorateStyles);
 				fs.Structure = _headerStyles;
 				fs.DivBlocks = _divBlocks;
 				MetaData(fs);
@@ -379,10 +379,7 @@ namespace CssSimpler
 					}
 					if (!string.IsNullOrEmpty(lastClass) || node.Name != "CLASS") continue;
 					var poposedClass = node.FirstChild.InnerText;
-					if (!NeedHigher.Contains(poposedClass))
-					{
-						lastClass = poposedClass;
-					}
+					lastClass = poposedClass;
 				}
 				ruleNode.Attributes.Append(xml.CreateAttribute("term"));
 				ruleNode.Attributes.Append(xml.CreateAttribute("pos"));
@@ -692,7 +689,6 @@ namespace CssSimpler
         private static string _target;
         private static bool _noData;
         private static int _term;
-        protected static readonly SortedSet<string> NeedHigher = new SortedSet<string> { "form", "sensenumber", "headword", "name", "writingsystemprefix", "xitem", "configtarget", "configtargets", "abbreviation", "ownertype_abbreviation" };
 
         protected static void AddSubTree(XmlNode n, CommonTree t, CssTreeParser ctp)
         {
@@ -777,14 +773,7 @@ namespace CssSimpler
                             _noData = true;
                         }
                         _target = name;
-                        if (!NeedHigher.Contains(name))
-                        {
-                            _lastClass = name;
-                        }
-                        else
-                        {
-                            VerboseMessage("skipping: {0}", name);
-                        }
+                        _lastClass = name;
                     }
                     if (n.Name == "TAG")
                     {

--- a/src/PsTool/PsTool.csproj
+++ b/src/PsTool/PsTool.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -488,7 +488,7 @@
   </Target>
   -->
   <Target Name="AfterBuild">
-    <Copy SourceFiles="..\..\lib\icudt56.dll;..\..\lib\icuin56.dll;..\..\lib\icuuc56.dll" DestinationFolder="$(OutputPath)" Condition=" '$(OS)' == 'Windows_NT' or '$(OS)' == '' " />
+    <Copy SourceFiles="..\..\lib\icudt56.dll;..\..\lib\icuin56.dll;..\..\lib\icuuc56.dll;..\..\lib\icu.net.dll" DestinationFolder="$(OutputPath)" Condition=" '$(OS)' == 'Windows_NT' or '$(OS)' == '' " />
   </Target>
   <PropertyGroup>
     <PostBuildEvent>

--- a/src/Test/CssSimpler/CssSimplerTest.cs
+++ b/src/Test/CssSimpler/CssSimplerTest.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------
 // <copyright file="CssSimplerTest.cs" from='2016' to='2016' company='SIL International'>
 //      Copyright (C) 2016, SIL International. All Rights Reserved.
 //
@@ -195,7 +195,7 @@ namespace Test.CssSimplerTest
             Assert.AreEqual("9", termnode3.InnerText, "Third rule should have nine selector terms");
             var lastClass = xml.SelectSingleNode("//RULE[3]/@lastClass");
             Debug.Assert(lastClass != null, "lastClass != null");
-            Assert.AreEqual("pronunciation", lastClass.InnerText, "Last class name on the third rule should be pronunciation");
+            Assert.AreEqual("form", lastClass.InnerText, "Last class name on the third rule should be form");
             var target = xml.SelectSingleNode("//RULE[3]/@target");
             Debug.Assert(target != null, "target != null");
             Assert.AreEqual("span", target.InnerText, "The target css selector for the third rule should be span");
@@ -240,9 +240,9 @@ namespace Test.CssSimplerTest
             LoadCssXml(ctp, cssFullName, xml);
             var tmpOut = Path.GetTempFileName();
             // ReSharper disable once UnusedVariable
-            var ps = new ProcessPseudo(xhtmlFullName, tmpOut, xml, NeedHigher);
+            var ps = new ProcessPseudo(xhtmlFullName, tmpOut, xml);
             RemoveCssPseudo(cssFullName, xml);
-            var fs = new FlattenStyles(tmpOut, outFullName, xml, NeedHigher, false, "");
+            var fs = new FlattenStyles(tmpOut, outFullName, xml, false, "");
             fs.Parse();
             WriteXmlAsCss(cssFullName, fs.MakeFlatCss());
             NodeTest(outFullName, 2, "//*[starts-with(@class,'example')]", "wrong number of example nodes");
@@ -269,9 +269,9 @@ namespace Test.CssSimplerTest
             LoadCssXml(ctp, cssFullName, xml);
             var tmpOut = Path.GetTempFileName();
             // ReSharper disable once UnusedVariable
-            var ps = new ProcessPseudo(xhtmlFullName, tmpOut, xml, NeedHigher);
+            var ps = new ProcessPseudo(xhtmlFullName, tmpOut, xml);
             RemoveCssPseudo(cssFullName, xml);
-            var fs = new FlattenStyles(tmpOut, outFullName, xml, NeedHigher, false, "");
+            var fs = new FlattenStyles(tmpOut, outFullName, xml, false, "");
             fs.Parse();
             WriteXmlAsCss(cssFullName, fs.MakeFlatCss());
             NodeTest(outFullName, 0, "//*[local-name()='span'][@class='pictures']", "pictures node present when it shouldn't be");
@@ -383,7 +383,7 @@ namespace Test.CssSimplerTest
             xml.RemoveAll();
             UniqueClasses = null;
             LoadCssXml(parser, styleSheet, xml);
-            new ProcessPseudo(tmp2Out, xhtmlFullName, xml, NeedHigher);
+            new ProcessPseudo(tmp2Out, xhtmlFullName, xml);
             RemoveCssPseudo(styleSheet, xml);
             try
             {
@@ -422,7 +422,7 @@ namespace Test.CssSimplerTest
 			xml.RemoveAll();
 			UniqueClasses = null;
 			LoadCssXml(parser, styleSheet, xml);
-			new ProcessPseudo(tmp2Out, xhtmlFullName, xml, NeedHigher);
+			new ProcessPseudo(tmp2Out, xhtmlFullName, xml);
 			RemoveCssPseudo(styleSheet, xml);
 			try
 			{
@@ -460,7 +460,7 @@ namespace Test.CssSimplerTest
             xml.RemoveAll();
             UniqueClasses = null;
             LoadCssXml(parser, styleSheet, xml);
-            new ProcessPseudo(tmp2Out, xhtmlFullName, xml, NeedHigher);
+            new ProcessPseudo(tmp2Out, xhtmlFullName, xml);
             RemoveCssPseudo(styleSheet, xml);
             try
             {
@@ -498,7 +498,7 @@ namespace Test.CssSimplerTest
             xml.RemoveAll();
             UniqueClasses = null;
             LoadCssXml(parser, styleSheet, xml);
-            new ProcessPseudo(tmp2Out, xhtmlFullName, xml, NeedHigher);
+            new ProcessPseudo(tmp2Out, xhtmlFullName, xml);
             RemoveCssPseudo(styleSheet, xml);
             try
             {
@@ -537,7 +537,7 @@ namespace Test.CssSimplerTest
             xml.RemoveAll();
             UniqueClasses = null;
             LoadCssXml(parser, styleSheet, xml);
-            new ProcessPseudo(tmp2Out, xhtmlFullName, xml, NeedHigher);
+            new ProcessPseudo(tmp2Out, xhtmlFullName, xml);
             RemoveCssPseudo(styleSheet, xml);
             try
             {
@@ -575,7 +575,7 @@ namespace Test.CssSimplerTest
             xml.RemoveAll();
             UniqueClasses = null;
             LoadCssXml(parser, styleSheet, xml);
-            new ProcessPseudo(tmp2Out, xhtmlFullName, xml, NeedHigher);
+            new ProcessPseudo(tmp2Out, xhtmlFullName, xml);
             RemoveCssPseudo(styleSheet, xml);
             try
             {
@@ -610,7 +610,7 @@ namespace Test.CssSimplerTest
             AddSubTree(xml.DocumentElement, root, ctp);
             _testFiles.Copy(testName + ".css");
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             NodeTest(outFullName, 3023, "//*[@xml:space]", "Nodes with pseudo content changed for Fw 8.2.8");
         }
@@ -636,7 +636,7 @@ namespace Test.CssSimplerTest
 			AddSubTree(xml.DocumentElement, root, ctp);
 			_testFiles.Copy(testName + ".css");
 			WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-			new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+			new ProcessPseudo(xhtmlFullName, outFullName, xml);
 			RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
 			NodeTest(outFullName, 2, "//*[@class='headword']//*[local-name()='a']/*", "Expected open and close parenthesis");
 		}
@@ -662,7 +662,7 @@ namespace Test.CssSimplerTest
             AddSubTree(xml.DocumentElement, root, ctp);
             _testFiles.Copy(testName + ".css");
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             NodeTest(outFullName, 1, "//*[@class='ownertype_abbreviation']/preceding-sibling::*", "node with ; not inserted between lexical relations");
         }
@@ -688,7 +688,7 @@ namespace Test.CssSimplerTest
             AddSubTree(xml.DocumentElement, root, ctp);
             _testFiles.Copy(testName + ".css");
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             NodeTest(outFullName, 2, "//*[@class='sensenumber']/*", "Wrong amount of sense number punctuation.");
         }
@@ -714,7 +714,7 @@ namespace Test.CssSimplerTest
             AddSubTree(xml.DocumentElement, root, ctp);
             _testFiles.Copy(testName + ".css");
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             TextFileAssert.AreEqual(_testFiles.Expected(testName + ".css"), _testFiles.Output(testName + ".css"));
             NodeTest(outFullName, 9, "//*[@class='headword']/preceding-sibling::*", "missing commas between lexical relation headwords");
@@ -741,7 +741,7 @@ namespace Test.CssSimplerTest
             AddSubTree(xml.DocumentElement, root, ctp);
             _testFiles.Copy(testName + ".css");
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             TextFileAssert.AreEqual(_testFiles.Expected(testName + ".css"), _testFiles.Output(testName + ".css"));
             NodeTest(outFullName, 81, "//*[@xml:space]", "subentry punctuation");
@@ -769,7 +769,7 @@ namespace Test.CssSimplerTest
             AddSubTree(xml.DocumentElement, root, ctp);
             _testFiles.Copy(testName + ".css");
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             TextFileAssert.AreEqual(_testFiles.Expected(testName + ".css"), _testFiles.Output(testName + ".css"));
             NodeTest(outFullName, 14, "//*[@class='semanticdomains']/*[@xml:space]", "semantic domain punctuation");
@@ -800,9 +800,9 @@ namespace Test.CssSimplerTest
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
             var tmp2OutFullName = Path.GetTempFileName();
             // ReSharper disable once UnusedVariable
-            var ps = new ProcessPseudo(xhtmlFullName, tmp2OutFullName, xml, NeedHigher);
+            var ps = new ProcessPseudo(xhtmlFullName, tmp2OutFullName, xml);
             RemoveCssPseudo(cssFullName, xml);
-            var fs = new FlattenStyles(tmp2OutFullName, outFullName, xml, NeedHigher, false, "");
+            var fs = new FlattenStyles(tmp2OutFullName, outFullName, xml, false, "");
             fs.Parse();
             WriteXmlAsCss(cssFullName, fs.MakeFlatCss());
             TextFileAssert.AreEqual(_testFiles.Expected(testName + ".css"), cssFullName);
@@ -831,7 +831,7 @@ namespace Test.CssSimplerTest
             AddSubTree(xml.DocumentElement, root, ctp);
             _testFiles.Copy(testName + ".css");
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             TextFileAssert.AreEqual(_testFiles.Expected(testName + ".css"), _testFiles.Output(testName + ".css"));
             NodeTest(outFullName, 7, "//*[@class='semanticdomain']/*[@class='abbreviation']/preceding-sibling::*", "multiple semantic domain punctuation");
@@ -856,7 +856,7 @@ namespace Test.CssSimplerTest
             _testFiles.Copy(testName + ".css");
             LoadCssXml(ctp, cssFullName, xml);
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             TextFileAssert.AreEqual(_testFiles.Expected(testName + ".css"), _testFiles.Output(testName + ".css"));
             NodeTest(outFullName, 131, "//*[@xml:space]", "semantic domain punctuation");
@@ -883,9 +883,9 @@ namespace Test.CssSimplerTest
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
             var tmp2Out = Path.GetTempFileName();
             // ReSharper disable once UnusedVariable
-            var ps = new ProcessPseudo(xhtmlFullName, tmp2Out, xml, NeedHigher);
+            var ps = new ProcessPseudo(xhtmlFullName, tmp2Out, xml);
             RemoveCssPseudo(cssFullName, xml);
-            var fs = new FlattenStyles(tmp2Out, outFullName, xml, NeedHigher, false, "");
+            var fs = new FlattenStyles(tmp2Out, outFullName, xml, false, "");
             fs.Parse();
             WriteXmlAsCss(cssFullName, fs.MakeFlatCss());
             TextFileAssert.AreEqual(_testFiles.Expected(testName + ".css"), cssFullName);
@@ -910,7 +910,7 @@ namespace Test.CssSimplerTest
             _testFiles.Copy(testName + ".css");
             LoadCssXml(ctp, cssFullName, xml);
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             NodeTest(outFullName, 1, "//*[@class='sensecontent']/*[@xml:space]", "comma between sense content");
         }
@@ -946,10 +946,10 @@ namespace Test.CssSimplerTest
             var tmp3Out = _testFiles.Output(testName + "T3.xhtml");
 
             // ReSharper disable once UnusedVariable
-            var ps = new ProcessPseudo(tmp2Out, tmp3Out, xml, NeedHigher);
+            var ps = new ProcessPseudo(tmp2Out, tmp3Out, xml);
             RemoveCssPseudo(cssFullName, xml);
             var flatFullName = _testFiles.Output(testName + "Flat.xhtml");
-            var fs = new FlattenStyles(tmp3Out, flatFullName, xml, NeedHigher, false, "");
+            var fs = new FlattenStyles(tmp3Out, flatFullName, xml, false, "");
             fs.Parse();
             WriteXmlAsCss(cssFullName, fs.MakeFlatCss());
             NodeTest(flatFullName, 1, "//*[starts-with(@class,'picture')]", "picture node missing");
@@ -976,7 +976,7 @@ namespace Test.CssSimplerTest
             LoadCssXml(ctp, cssFullName, xml);
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
             // ReSharper disable once UnusedVariable
-            var ps = new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            var ps = new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             NodeTest(outFullName, 1, "//*[@class='sensecontent']/*[@xml:space]", "comma between sense content");
         }
@@ -1012,10 +1012,10 @@ namespace Test.CssSimplerTest
             var tmp3Out = _testFiles.Output(testName + "T3.xhtml");
 
             // ReSharper disable once UnusedVariable
-            var ps = new ProcessPseudo(tmp2Out, tmp3Out, xml, NeedHigher);
+            var ps = new ProcessPseudo(tmp2Out, tmp3Out, xml);
             RemoveCssPseudo(cssFullName, xml);
             var flatFullName = _testFiles.Output(testName + "Flat.xhtml");
-            var fs = new FlattenStyles(tmp3Out, flatFullName, xml, NeedHigher, false, "");
+            var fs = new FlattenStyles(tmp3Out, flatFullName, xml, false, "");
             fs.Parse();
             WriteXmlAsCss(cssFullName, fs.MakeFlatCss());
             NodeTest(flatFullName, 4, "//*[starts-with(@class,'stxfinheadword')]", "headword with styles");
@@ -1106,7 +1106,7 @@ namespace Test.CssSimplerTest
             //WriteSimpleCss(_testFiles.Output(testName + ".css"), xml);
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
             // ReSharper disable once UnusedVariable
-            var ps = new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            var ps = new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             NodeTest(outFullName, 6, "//*[@xml:space]", "semantic domain punctuation");
         }
@@ -1133,7 +1133,7 @@ namespace Test.CssSimplerTest
             AddSubTree(xml.DocumentElement, root, ctp);
             _testFiles.Copy(testName + ".css");
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             NodeTest(outFullName, 1, "//*[@class='seh-Zxxx-x-audio']/*[string-length(.)=2]", "audio icon");
         }
@@ -1160,7 +1160,7 @@ namespace Test.CssSimplerTest
             AddSubTree(xml.DocumentElement, root, ctp);
             _testFiles.Copy(testName + ".css");
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             NodeTest(outFullName, 1, "//*[contains(@class,'subentry ')]/*[1][.='\x29EB']", "subentry bullet");
         }
@@ -1187,7 +1187,7 @@ namespace Test.CssSimplerTest
             AddSubTree(xml.DocumentElement, root, ctp);
             _testFiles.Copy(testName + ".css");
             WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-            new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+            new ProcessPseudo(xhtmlFullName, outFullName, xml);
             RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
             TextFileAssert.AreEqual(_testFiles.Expected(testName + ".css"), _testFiles.Output(testName + ".css"));
             NodeTest(outFullName, 2, "//*[@class='examplescontent-pb']", "examplebullet");
@@ -1215,7 +1215,7 @@ namespace Test.CssSimplerTest
 			AddSubTree(xml.DocumentElement, root, ctp);
 			_testFiles.Copy(testName + ".css");
 			WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-			new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+			new ProcessPseudo(xhtmlFullName, outFullName, xml);
 			RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
 			NodeTest(outFullName, 1, "//*[contains(@class,'subentry')]//*[contains(@class,'subentry')]//*[@class='subentry-pb']", "sub sub bullet");
 		}
@@ -1242,7 +1242,7 @@ namespace Test.CssSimplerTest
 			AddSubTree(xml.DocumentElement, root, ctp);
 			_testFiles.Copy(testName + ".css");
 			WriteCssXml(_testFiles.Output(testName + ".xml"), xml);
-			new ProcessPseudo(xhtmlFullName, outFullName, xml, NeedHigher);
+			new ProcessPseudo(xhtmlFullName, outFullName, xml);
 			RemoveCssPseudo(_testFiles.Output(testName + ".css"), xml);
 			NodeTest(outFullName, 1, "//*[contains(@class,'subentry')]//*[contains(@class,'subentry')]//*[@class='subentry-pb']", "sub sub bullet");
 		}
@@ -1263,7 +1263,7 @@ namespace Test.CssSimplerTest
 			var xml = new XmlDocument();
 			UniqueClasses = null;
 			LoadCssXml(parser, cssFullName, xml);
-			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, NeedHigher, false, "");
+			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, false, "");
 			fs.Structure = 0;
 			fs.DivBlocks = false;
 			MetaData(fs);
@@ -1297,9 +1297,9 @@ namespace Test.CssSimplerTest
 			UniqueClasses = null;
 			LoadCssXml(parser, styleSheet, xml);
 			// ReSharper disable once UnusedVariable
-			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml, NeedHigher);
+			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml);
 			RemoveCssPseudo(styleSheet, xml);
-			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, NeedHigher, false, "");
+			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, false, "");
 			fs.Structure = 0;
 			fs.DivBlocks = false;
 			MetaData(fs);
@@ -1334,9 +1334,9 @@ namespace Test.CssSimplerTest
 			UniqueClasses = null;
 			LoadCssXml(parser, styleSheet, xml);
 			// ReSharper disable once UnusedVariable
-			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml, NeedHigher);
+			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml);
 			RemoveCssPseudo(styleSheet, xml);
-			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, NeedHigher, false, "");
+			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, false, "");
 			fs.Structure = 0;
 			fs.DivBlocks = false;
 			MetaData(fs);
@@ -1370,9 +1370,9 @@ namespace Test.CssSimplerTest
 			UniqueClasses = null;
 			LoadCssXml(parser, styleSheet, xml);
 			// ReSharper disable once UnusedVariable
-			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml, NeedHigher);
+			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml);
 			RemoveCssPseudo(styleSheet, xml);
-			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, NeedHigher, false, "");
+			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, false, "");
 			fs.Structure = 0;
 			fs.DivBlocks = false;
 			MetaData(fs);
@@ -1411,9 +1411,9 @@ namespace Test.CssSimplerTest
 			LoadCssXml(parser, styleSheet, xml);
 			var tmp3Out = Path.GetTempFileName();
 			// ReSharper disable once UnusedVariable
-			var ps = new ProcessPseudo(tmp2Out, tmp3Out, xml, NeedHigher);
+			var ps = new ProcessPseudo(tmp2Out, tmp3Out, xml);
 			RemoveCssPseudo(styleSheet, xml);
-			var fs = new FlattenStyles(tmp3Out, xhtmlOutFullName, xml, NeedHigher, false, "");
+			var fs = new FlattenStyles(tmp3Out, xhtmlOutFullName, xml, false, "");
 			fs.Structure = 0;
 			fs.DivBlocks = false;
 			MetaData(fs);
@@ -1455,9 +1455,9 @@ namespace Test.CssSimplerTest
 			LoadCssXml(parser, styleSheet, xml);
 			var tmp3Out = Path.GetTempFileName();
 			// ReSharper disable once UnusedVariable
-			var ps = new ProcessPseudo(tmp2Out, tmp3Out, xml, NeedHigher);
+			var ps = new ProcessPseudo(tmp2Out, tmp3Out, xml);
 			RemoveCssPseudo(styleSheet, xml);
-			var fs = new FlattenStyles(tmp3Out, xhtmlOutFullName, xml, NeedHigher, false, "");
+			var fs = new FlattenStyles(tmp3Out, xhtmlOutFullName, xml, false, "");
 			fs.Structure = 0;
 			fs.DivBlocks = false;
 			MetaData(fs);
@@ -1493,9 +1493,9 @@ namespace Test.CssSimplerTest
 			UniqueClasses = null;
 			LoadCssXml(parser, styleSheet, xml);
 			// ReSharper disable once UnusedVariable
-			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml, NeedHigher);
+			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml);
 			RemoveCssPseudo(styleSheet, xml);
-			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, NeedHigher, false, "");
+			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, false, "");
 			fs.Structure = 0;
 			fs.DivBlocks = false;
 			MetaData(fs);
@@ -1526,9 +1526,9 @@ namespace Test.CssSimplerTest
 			UniqueClasses = null;
 			LoadCssXml(parser, styleSheet, xml);
 			// ReSharper disable once UnusedVariable
-			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml, NeedHigher);
+			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml);
 			RemoveCssPseudo(styleSheet, xml);
-			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, NeedHigher, false, "");
+			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, false, "");
 			fs.SpaceClass = string.Empty; // When class name set to empty string, no spans will be created.
 			fs.Structure = 0;
 			fs.DivBlocks = false;
@@ -1559,9 +1559,9 @@ namespace Test.CssSimplerTest
 			UniqueClasses = null;
 			LoadCssXml(parser, styleSheet, xml);
 			// ReSharper disable once UnusedVariable
-			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml, NeedHigher);
+			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml);
 			RemoveCssPseudo(styleSheet, xml);
-			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, NeedHigher, false, "");
+			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, false, "");
 			fs.Structure = 0;
 			fs.DivBlocks = false;
 			MetaData(fs);
@@ -1591,9 +1591,9 @@ namespace Test.CssSimplerTest
 			UniqueClasses = null;
 			LoadCssXml(parser, styleSheet, xml);
 			// ReSharper disable once UnusedVariable
-			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml, NeedHigher);
+			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml);
 			RemoveCssPseudo(styleSheet, xml);
-			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, NeedHigher, false, "");
+			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, false, "");
 			fs.Structure = 0;
 			fs.DivBlocks = false;
 			MetaData(fs);
@@ -1627,9 +1627,9 @@ namespace Test.CssSimplerTest
 			UniqueClasses = null;
 			LoadCssXml(parser, styleSheet, xml);
 			// ReSharper disable once UnusedVariable
-			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml, NeedHigher);
+			var ps = new ProcessPseudo(tmpXhtmlFullName, xhtmlFullName, xml);
 			RemoveCssPseudo(styleSheet, xml);
-			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, NeedHigher, false, "");
+			var fs = new FlattenStyles(xhtmlFullName, xhtmlOutFullName, xml, false, "");
 			fs.Structure = 0;
 			fs.DivBlocks = false;
 			MetaData(fs);


### PR DESCRIPTION
These changes were made to fix a problem with spaces being lost when exporting from FLEX to pathway.  FLEX does not always nest the classes that were on the NeedHigher list in other classes.

https://jira.sil.org/browse/LT-21634